### PR TITLE
Update article templates context and deprecate latest block

### DIFF
--- a/cms/contents/article/admin/_read_general.html.twig
+++ b/cms/contents/article/admin/_read_general.html.twig
@@ -4,9 +4,9 @@
     {% trans_default_domain 'sfs_cms_contents' %}
 
     {% block title %}
-        {% if entity.publishedVersion %}
-            {% if not content_config.admin.unpublish.is_granted or is_granted(content_config.admin.unpublish.is_granted, entity) %}
-                <a class="btn btn-sm btn-outline-secondary float-end"  href="{{ url('sfs_cms_admin_content_'~content_type~'_unpublish', {'content':entity.id}) }}"
+        {% if content_entity.publishedVersion %}
+            {% if not content_config.admin.unpublish.is_granted or is_granted(content_config.admin.unpublish.is_granted, content_entity) %}
+                <a class="btn btn-sm btn-outline-secondary float-end"  href="{{ url('sfs_cms_admin_content_'~content_type~'_unpublish', {'content':content_entity.id}) }}"
                    data-confirm-modal="{{ ('admin_'~content_type~'.version_unpublish.confirm_message_raw')|trans|base64_encode }}"
                    data-confirm-modal-title="{{ ('admin_'~content_type~'.version_unpublish.confirm_message_title')|trans }}"
                    data-confirm-modal-confirm-button-type="danger"
@@ -21,30 +21,30 @@
     {% block content %}
         <dl>
             <dt>{{ ('admin_'~content_type~'.read.name')|trans }}</dt>
-            <dd>{{ entity.name }}</dd>
+            <dd>{{ content_entity.name }}</dd>
             <dt>{{ ('admin_'~content_type~'.read.sites')|trans }}</dt>
-            <dd>{{ entity.sites|map((site) => site|sfs_cms_site_name)|join(', ') }}</dd>
+            <dd>{{ content_entity.sites|map((site) => site|sfs_cms_site_name)|join(', ') }}</dd>
             <dt>{{ ('admin_'~content_type~'.read.general.status')|trans }}</dt>
             <dd>
-                {{ (content_type~'.status.'~entity.status)|trans }}
-                {% if entity.publishedVersion %}
-                    (<a href="{{ url('sfs_cms_admin_content_'~content_type~'_version_info', {'content':entity, 'version':entity.publishedVersion}) }}">v{{ entity.publishedVersion.versionNumber }}</a>)
+                {{ (content_type~'.status.'~content_entity.status)|trans }}
+                {% if content_entity.publishedVersion %}
+                    (<a href="{{ url('sfs_cms_admin_content_'~content_type~'_version_info', {'content':content_entity, 'version':content_entity.publishedVersion}) }}">v{{ content_entity.publishedVersion.versionNumber }}</a>)
                 {% endif %}
             </dd>
-            {% if entity.publishedVersion %}
+            {% if content_entity.publishedVersion %}
                 <dt>{{ ('admin_'~content_type~'.read.general.publishDate')|trans }}</dt>
                 <dd>
-                    {% if entity.lastModified %}
-                        {{ entity.lastModified|date('H:i d-m-Y') }}
+                    {% if content_entity.lastModified %}
+                        {{ content_entity.lastModified|date('H:i d-m-Y') }}
                     {% endif %}
                 </dd>
             {% endif %}
             <dt>{{ ('admin_'~content_type~'.read.general.author')|trans }}</dt>
             <dd>
                 <div class="rounded me-3 d-inline">
-                    <img src="{{ entity.author.avatarUrl }}" alt="{{ entity.author.name }}" class="rounded-circle" width="20" height="20" />
+                    <img src="{{ content_entity.author.avatarUrl }}" alt="{{ content_entity.author.name }}" class="rounded-circle" width="20" height="20" />
                 </div>
-                {{ entity.author.displayName }}
+                {{ content_entity.author.displayName }}
             </dd>
 {#            <dt>{{ ('admin_'~content_type~'.read.readingTime')|trans }}</dt>#}
         </dl>

--- a/cms/contents/article/admin/list-page.html.twig
+++ b/cms/contents/article/admin/list-page.html.twig
@@ -1,29 +1,29 @@
 {% trans_default_domain 'sfs_cms_contents' %}
 
-{% for entity in collection %}
+{% for content_entity in collection %}
     <tr
-            {% if not content_config.admin.read.is_granted or is_granted(content_config.admin.read.is_granted, entity) %}
-                data-row-href="{{ url('sfs_cms_admin_content_'~content_type~'_details', {'content':entity.id}) }}"
+            {% if not content_config.admin.read.is_granted or is_granted(content_config.admin.read.is_granted, content_entity) %}
+                data-row-href="{{ url('sfs_cms_admin_content_'~content_type~'_details', {'content':content_entity.id}) }}"
             {% endif %}
     >
         <td class="p-3">
             <div class="rounded me-3">
-                <img src="{{ entity.author.avatarUrl }}" alt="{{ entity.author.name }}" class="rounded-circle" width="20" height="20" />
+                <img src="{{ content_entity.author.avatarUrl }}" alt="{{ content_entity.author.name }}" class="rounded-circle" width="20" height="20" />
             </div>
         </td>
-        <td class="p-3">{{ entity.name }}</td>
-        <td class="p-3">{{ entity.sitesSorted|map((site) => site|sfs_cms_site_name)|join(', ') }}</td>
-        <td class="p-3">{{ (content_type~'.status.'~entity.status)|trans }}</td>
-        <td class="p-3">{{ entity.publishedVersion ? entity.publishedVersion.createdAt|date('H:i d-m-Y') : '' }}</td>
+        <td class="p-3">{{ content_entity.name }}</td>
+        <td class="p-3">{{ content_entity.sitesSorted|map((site) => site|sfs_cms_site_name)|join(', ') }}</td>
+        <td class="p-3">{{ (content_type~'.status.'~content_entity.status)|trans }}</td>
+        <td class="p-3">{{ content_entity.publishedVersion ? content_entity.publishedVersion.createdAt|date('H:i d-m-Y') : '' }}</td>
         <td class="p-3 text-end">
-            {% if not content_config.admin.read.is_granted or is_granted(content_config.admin.read.is_granted, entity) %}
-                <a href="{{ url('sfs_cms_admin_content_'~content_type~'_details', {'content':entity}) }}" class="ms-2 text-nowrap hidden-on-clickable-row">{{ ('admin_'~content_type~'.list.actions.details.link')|trans }} <span class="bi bi-info"></span></a>
+            {% if not content_config.admin.read.is_granted or is_granted(content_config.admin.read.is_granted, content_entity) %}
+                <a href="{{ url('sfs_cms_admin_content_'~content_type~'_details', {'content':content_entity}) }}" class="ms-2 text-nowrap hidden-on-clickable-row">{{ ('admin_'~content_type~'.list.actions.details.link')|trans }} <span class="bi bi-info"></span></a>
             {% endif %}
-            {% if not content_config.admin.version_create.is_granted or is_granted(content_config.admin.version_create.is_granted, entity) %}
-                <a href="{{ url('sfs_cms_admin_content_'~content_type~'_content', {'content':entity}) }}" class="ms-2 text-nowrap">{{ ('admin_'~content_type~'.list.actions.content.link')|trans }} <span class="bi bi-pencil"></span></a>
+            {% if not content_config.admin.version_create.is_granted or is_granted(content_config.admin.version_create.is_granted, content_entity) %}
+                <a href="{{ url('sfs_cms_admin_content_'~content_type~'_content', {'content':content_entity}) }}" class="ms-2 text-nowrap">{{ ('admin_'~content_type~'.list.actions.content.link')|trans }} <span class="bi bi-pencil"></span></a>
             {% endif %}
-            {% if not content_config.admin.preview.is_granted or is_granted(content_config.admin.preview.is_granted, entity) %}
-                <a href="{{ url('sfs_cms_admin_content_'~content_type~'_preview', {'content':entity}) }}" class="ms-2 text-nowrap">{{ ('admin_'~content_type~'.list.actions.preview.link')|trans }} <span class="bi bi-eye"></span></a>
+            {% if not content_config.admin.preview.is_granted or is_granted(content_config.admin.preview.is_granted, content_entity) %}
+                <a href="{{ url('sfs_cms_admin_content_'~content_type~'_preview', {'content':content_entity}) }}" class="ms-2 text-nowrap">{{ ('admin_'~content_type~'.list.actions.preview.link')|trans }} <span class="bi bi-eye"></span></a>
             {% endif %}
         </td>
     </tr>

--- a/cms/contents/article/translations/sfs_cms_contents.es.yaml
+++ b/cms/contents/article/translations/sfs_cms_contents.es.yaml
@@ -317,6 +317,7 @@ admin_article:
             metaTitle.label: "Título (título del navegador y etiquetas meta)"
             metaDescription.label: "Descripción (etiqueta meta)"
             metaKeywords.label: "Palabras clave (etiqueta meta)"
+            canonicalContent.label: "Contenido canónico"
         title.label: "Título del artículo"
         description.label: "Excerpt"
         reading_minutes.label: "Tiempo de lectura (minutos)"

--- a/cms/layouts/article/edit.html.twig
+++ b/cms/layouts/article/edit.html.twig
@@ -1,15 +1,15 @@
 {% block body %}
     <main role="main">
         <div class="container">
-            {% for locale,title in entity.extraData.title %}
+            {% for locale,title in content_entity.extraData.title %}
                 <h1 data-lang="{{ locale }}">{{ title }}</h1>
             {% endfor %}
 
-            {% for locale,description in entity.extraData.description %}
+            {% for locale,description in content_entity.extraData.description %}
                 <p data-lang="{{ locale }}">{{ description }}</p>
             {% endfor %}
 
-            {{ sfs_cms_block_by_type('article_header_data', {'article': entity.id}) }}
+            {{ sfs_cms_block_by_type('article_header_data', {'article': content_entity.id}) }}
 
             {{ form_row(form.data.main) }}
         </div>

--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,13 @@
         "symfony/translation": "^6.4 || ^7.4 || ^8.0"
     },
     "require-dev": {
-        "softspring/cms-data-plugin": "^6.0@dev",
         "ergebnis/composer-normalize": "^2.50",
         "friendsofphp/php-cs-fixer": "^3.94",
         "guzzlehttp/guzzle": "^7.8.2",
         "guzzlehttp/promises": "^2.0",
         "phpstan/phpstan": "^2.1",
-        "rector/rector": "^2.3"
+        "rector/rector": "^2.3",
+        "softspring/cms-data-plugin": "^6.0@dev"
     },
     "suggest": {
         "softspring/user-bundle": "If you want to use users as blog authors"

--- a/src/Controller/ArticleController.php
+++ b/src/Controller/ArticleController.php
@@ -88,6 +88,8 @@ class ArticleController extends AbstractController
      */
     public function latestBlock(Request $request): Response
     {
+        trigger_deprecation('softspring/cms-blog-plugin', '6.0', 'The "article_latest_list" block is deprecated, use the "article_link_list" module instead.');
+
         $locale = $this->setLocale($request);
 
         $query = $this->getPublicQuery($request);

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Softspring\CmsBlogPlugin\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;

--- a/src/Entity/ArticleContent.php
+++ b/src/Entity/ArticleContent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Softspring\CmsBlogPlugin\Entity;
 
 use DateTime;

--- a/src/EventListener/OverrideDoctrineClassSuperclassListener.php
+++ b/src/EventListener/OverrideDoctrineClassSuperclassListener.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Softspring\CmsBlogPlugin\EventListener;
 
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;

--- a/src/Form/Admin/Article/ArticleCreateForm.php
+++ b/src/Form/Admin/Article/ArticleCreateForm.php
@@ -1,22 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Softspring\CmsBlogPlugin\Form\Admin\Article;
 
 use Softspring\CmsBlogPlugin\Form\Type\ArticleTagsType;
 use Softspring\CmsBlogPlugin\Model\ArticleAuthorInterface;
 use Softspring\CmsBundle\Form\Admin\Content\ContentCreateForm;
 use Softspring\CmsBundle\Form\Type\UserType;
-use Softspring\CmsBundle\Translator\TranslatableContext;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 class ArticleCreateForm extends ContentCreateForm
 {
-    public function __construct(TranslatableContext $translatableContext)
-    {
-        parent::__construct($translatableContext);
-    }
-
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         parent::buildForm($builder, $options);

--- a/src/Form/Admin/Article/ArticleDuplicateForm.php
+++ b/src/Form/Admin/Article/ArticleDuplicateForm.php
@@ -1,23 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Softspring\CmsBlogPlugin\Form\Admin\Article;
 
-use Doctrine\ORM\EntityManagerInterface;
 use Softspring\CmsBlogPlugin\Form\Type\ArticleTagsType;
 use Softspring\CmsBlogPlugin\Model\ArticleAuthorInterface;
 use Softspring\CmsBundle\Form\Admin\Content\ContentDuplicateForm;
 use Softspring\CmsBundle\Form\Type\UserType;
-use Softspring\CmsBundle\Translator\TranslatableContext;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 class ArticleDuplicateForm extends ContentDuplicateForm
 {
-    public function __construct(TranslatableContext $translatableContext, EntityManagerInterface $em)
-    {
-        parent::__construct($translatableContext, $em);
-    }
-
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         parent::buildForm($builder, $options);

--- a/src/Form/Admin/Article/ArticleListFilterForm.php
+++ b/src/Form/Admin/Article/ArticleListFilterForm.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Softspring\CmsBlogPlugin\Form\Admin\Article;
 
 use Softspring\CmsBlogPlugin\Model\AuthorInterface;

--- a/src/Form/Admin/Article/ArticleUpdateForm.php
+++ b/src/Form/Admin/Article/ArticleUpdateForm.php
@@ -1,22 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Softspring\CmsBlogPlugin\Form\Admin\Article;
 
 use Softspring\CmsBlogPlugin\Form\Type\ArticleTagsType;
 use Softspring\CmsBlogPlugin\Model\ArticleAuthorInterface;
 use Softspring\CmsBundle\Form\Admin\Content\ContentUpdateForm;
 use Softspring\CmsBundle\Form\Type\UserType;
-use Softspring\CmsBundle\Translator\TranslatableContext;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 class ArticleUpdateForm extends ContentUpdateForm
 {
-    public function __construct(TranslatableContext $translatableContext)
-    {
-        parent::__construct($translatableContext);
-    }
-
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         parent::buildForm($builder, $options);

--- a/src/Form/ArticleListFilterForm.php
+++ b/src/Form/ArticleListFilterForm.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Softspring\CmsBlogPlugin\Form;
 
 use Softspring\CmsBlogPlugin\Entity\ArticleContent;

--- a/src/Form/Type/ArticleTagsType.php
+++ b/src/Form/Type/ArticleTagsType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Softspring\CmsBlogPlugin\Form\Type;
 
 use Softspring\CmsBlogPlugin\Manager\ArticleTagManager;
@@ -23,7 +25,7 @@ class ArticleTagsType extends AbstractType
         $builder->addModelTransformer(new CallbackTransformer(
             fn (?array $tags): string => json_encode($tags ?? [], JSON_THROW_ON_ERROR),
             function (?string $tags): array {
-                if (empty($tags)) {
+                if (in_array($tags, [null, '', '0'], true)) {
                     return [];
                 }
 

--- a/src/Form/Type/BlogArticleTagType.php
+++ b/src/Form/Type/BlogArticleTagType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Softspring\CmsBlogPlugin\Form\Type;
 
 use Softspring\CmsBlogPlugin\Manager\ArticleTagManager;
@@ -21,7 +23,7 @@ class BlogArticleTagType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $tags = $this->articleTagManager->getExistingTags();
-        $choices = array_combine($tags, $tags) ?: [];
+        $choices = array_combine($tags, $tags);
 
         $resolver->setDefaults([
             'required' => false,

--- a/src/Model/ArticleAuthorInterface.php
+++ b/src/Model/ArticleAuthorInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Softspring\CmsBlogPlugin\Model;
 
 interface ArticleAuthorInterface

--- a/src/Model/ArticleContentInterface.php
+++ b/src/Model/ArticleContentInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Softspring\CmsBlogPlugin\Model;
 
 use DateTime;

--- a/src/Model/AuthorInterface.php
+++ b/src/Model/AuthorInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Softspring\CmsBlogPlugin\Model;
 
 interface AuthorInterface


### PR DESCRIPTION
Summary:\n- Rename article admin/layout Twig context from entity to content_entity.\n- Add deprecation notice for article_latest_list block, pointing to article_link_list.\n\nValidation:\n- lint:twig passed for affected templates.\n- php -l passed for ArticleController.